### PR TITLE
Fix analytics timezone bug, switch to marked.js for tip rendering

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -684,8 +684,9 @@ h3 { font-size: 1.125rem; font-weight: 600; margin: 20px 0 10px; }
   margin-bottom: 14px;
 }
 
-/* ---------- Markdown-rendered tips (setup + form) ---------- */
-.tips-header {
+/* ---------- Markdown-rendered tips (setup + form via marked.js) ---------- */
+.setup-notes-text h3,
+#form-text h3 {
   font-size: 0.8rem;
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -693,33 +694,24 @@ h3 { font-size: 1.125rem; font-weight: 600; margin: 20px 0 10px; }
   color: var(--accent);
   margin: 14px 0 4px;
 }
-.tips-header:first-child {
+.setup-notes-text h3:first-child,
+#form-text h3:first-child {
   margin-top: 0;
 }
-.tips-list {
+.setup-notes-text ul,
+#form-text ul {
   margin: 0 0 4px 0;
   padding-left: 1.25em;
 }
-.tips-list li {
+.setup-notes-text li,
+#form-text li {
   margin-bottom: 4px;
   line-height: 1.5;
 }
-.tips-p {
+.setup-notes-text p,
+#form-text p {
   margin: 4px 0;
   line-height: 1.5;
-}
-.tips-cue {
-  display: inline-block;
-  font-weight: 600;
-  color: var(--text);
-  background: var(--bg-input);
-  border-radius: var(--radius-sm);
-  padding: 6px 10px;
-  margin: 6px 0 2px;
-  font-size: 0.9rem;
-}
-.tips-spacer {
-  height: 6px;
 }
 
 /* Assisted chin inversion note */

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <meta name="theme-color" content="#f0f0f5" media="(prefers-color-scheme: light)">
   <title>Gym</title>
   <link rel="stylesheet" href="css/app.css">
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
 <body>
 

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -2,7 +2,7 @@
  * Gym App — Analytics (heatmap, weekly charts)
  */
 
-import { $, formatDuration } from './utils.js';
+import { $, formatDuration, localDateStr } from './utils.js';
 import { App } from './state.js';
 
 // ============================================================
@@ -21,10 +21,10 @@ function renderHeatmap() {
   const sessions = App.data.sessions || [];
   const now = new Date();
 
-  // Build a map of date => dayType
+  // Build a map of local date => dayType
   const dateMap = {};
   sessions.forEach(s => {
-    const date = s.startedAt.split('T')[0];
+    const date = localDateStr(new Date(s.startedAt));
     dateMap[date] = s.dayType;
   });
 
@@ -95,7 +95,7 @@ function renderHeatmap() {
 
   // Heatmap cells (grid-auto-flow: column fills top→bottom per week column)
   dates.forEach(date => {
-    const dateStr = date.toISOString().split('T')[0];
+    const dateStr = localDateStr(date);
     const dayType = dateMap[dateStr] || null;
     const isFuture = date > now;
 
@@ -134,7 +134,7 @@ function renderHeatmap() {
 }
 
 function showDaySummary(dateStr) {
-  const sessions = App.data.sessions.filter(s => s.startedAt.startsWith(dateStr));
+  const sessions = (App.data.sessions || []).filter(s => localDateStr(new Date(s.startedAt)) === dateStr);
   if (sessions.length === 0) return;
 
   const container = $('day-summary');
@@ -170,7 +170,7 @@ function getWeeklyData(metric) {
     // Get week start (Sunday)
     const weekStart = new Date(date);
     weekStart.setDate(weekStart.getDate() - weekStart.getDay());
-    const weekKey = weekStart.toISOString().split('T')[0];
+    const weekKey = localDateStr(weekStart);
 
     if (!weeks[weekKey]) weeks[weekKey] = 0;
 
@@ -188,7 +188,7 @@ function getWeeklyData(metric) {
   for (let i = 11; i >= 0; i--) {
     const d = new Date(now);
     d.setDate(d.getDate() - d.getDay() - (i * 7));
-    const key = d.toISOString().split('T')[0];
+    const key = localDateStr(d);
     const month = d.getMonth() + 1;
     const day = d.getDate();
     result.push({

--- a/js/config.js
+++ b/js/config.js
@@ -6,7 +6,7 @@ export const STORAGE_KEY = 'gymApp_v1_data';
 export const SESSION_KEY = 'gymApp_v1_activeSession';
 // Version: date-based (YYYY.MM.DD + build letter). Update on every code change.
 // Same day: increment letter (a→b→c). New day: reset to 'a'.
-export const APP_VERSION = 'v2026.03.08a';
+export const APP_VERSION = 'v2026.03.10a';
 
 export const REST_TARGETS = {
   compound:  { normal: 90, hurry: 60 }, // seconds

--- a/js/utils.js
+++ b/js/utils.js
@@ -29,69 +29,31 @@ export function $$(sel) { return document.querySelectorAll(sel); }
 
 export function isoNow() { return new Date().toISOString(); }
 
+/** Return 'YYYY-MM-DD' in the user's local timezone */
+export function localDateStr(date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
 /**
- * Convert a markdown-like tips string to safe HTML.
- * Supported syntax:
- *   **Header**        → styled section header
- *   • text / - text   → list items (grouped into <ul>)
- *   🗣️ "..."          → micro-cue callout block
- *   blank line        → paragraph break / list separator
- *   everything else   → <p> paragraph
+ * Convert a markdown tips string to HTML using marked.js.
+ * Pre-processes legacy format (• bullets, **Header** lines) into standard markdown.
  */
 export function renderMarkdown(text) {
   if (!text) return '';
-  const lines = text.split('\n');
-  let html = '';
-  let inList = false;
 
-  const closeList = () => {
-    if (inList) { html += '</ul>'; inList = false; }
-  };
+  // Pre-process: convert legacy format to standard markdown
+  const processed = text
+    // **Header** on its own line → ### Header (so marked renders as <h3>)
+    .replace(/^\*\*(.+)\*\*$/gm, '### $1')
+    // Unicode bullets → standard markdown list items
+    .replace(/^[•✦]\s/gm, '- ')
+    // Strip leading tabs (from template literals)
+    .replace(/^\t+/gm, '');
 
-  for (const rawLine of lines) {
-    const line = rawLine.replace(/^\t+/, '').trimEnd();
-
-    // Blank line → close list, add spacing
-    if (line.trim() === '') {
-      closeList();
-      html += '<div class="tips-spacer"></div>';
-      continue;
-    }
-
-    // **Header** → section header
-    const headerMatch = line.match(/^\*\*(.+)\*\*$/);
-    if (headerMatch) {
-      closeList();
-      html += `<div class="tips-header">${escHtml(headerMatch[1])}</div>`;
-      continue;
-    }
-
-    // Bullet: leading •, -, or ✦ (optionally with leading whitespace/tab)
-    const bulletMatch = line.match(/^[\s]*[•\-✦]\s+(.*)/);
-    if (bulletMatch) {
-      if (!inList) { html += '<ul class="tips-list">'; inList = true; }
-      html += `<li>${escHtml(bulletMatch[1])}</li>`;
-      continue;
-    }
-
-    // Micro-cue line: starts with an emoji and contains a closing quote (smart or straight)
-    const cueLine = line.trim();
-    const startsWithEmoji = /^\p{Extended_Pictographic}/u.test(cueLine);
-    const hasQuote = /[\u201c\u201d\u2019"']/.test(cueLine);
-    const isMicroCue = (startsWithEmoji && hasQuote) || /^Micro-cue/.test(cueLine);
-    if (isMicroCue) {
-      closeList();
-      html += `<div class="tips-cue">${escHtml(cueLine)}</div>`;
-      continue;
-    }
-
-    // Regular line → paragraph
-    closeList();
-    html += `<p class="tips-p">${escHtml(cueLine)}</p>`;
-  }
-
-  closeList();
-  return html;
+  return window.marked.parse(processed);
 }
 
 /** Strip markdown formatting for TTS plain text */
@@ -104,11 +66,3 @@ export function stripMarkdown(text) {
     .trim();
 }
 
-/** HTML-escape a string */
-function escHtml(str) {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-}


### PR DESCRIPTION
- Fix heatmap/charts using UTC dates instead of local dates, which caused
  evening workouts to appear on the wrong day in US timezones
- Replace custom renderMarkdown() with marked.js via CDN for standard
  markdown rendering of setup/form tips
- Add localDateStr() utility for consistent local date formatting
- Update CSS to style marked.js output (h3, ul, li, p) within tip containers
- Add null-safety to showDaySummary session lookup
- Bump version to v2026.03.10a

https://claude.ai/code/session_01DM5L8Y18Z9TTmGKrnZq5zd