### PR TITLE
Rethink set logging flow: Set Done → data entry (issue #15)

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1067,49 +1067,12 @@ h3 { font-size: 1.125rem; font-weight: 600; margin: 20px 0 10px; }
   animation: restPulse 1s ease-in-out 3;
 }
 
-/* ---------- Backdate Overlay (bottom sheet modal) ---------- */
-#backdate-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 95;
-  background: var(--overlay);
-  display: flex;
-  align-items: flex-end;
-  animation: fadeIn 200ms ease;
-}
-#backdate-overlay.hidden { display: none !important; }
-
-#backdate-sheet {
-  width: 100%;
-  background: var(--bg-card);
-  border-radius: 20px 20px 0 0;
-  padding: 24px 20px;
-  padding-bottom: calc(24px + env(safe-area-inset-bottom, 0px));
-  border-top: 3px solid var(--accent);
-  animation: slideUp 250ms ease;
-}
-
-#backdate-title {
-  font-size: 1rem;
-  font-weight: 700;
-  text-align: center;
-  margin-bottom: 16px;
-  color: var(--text-secondary);
-}
-
-#backdate-sheet #backdate-chips {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 10px;
-}
-#backdate-sheet .chip {
-  padding: 14px 8px;
-  font-size: 1rem;
-  font-weight: 700;
-  min-height: 52px;
-  border-radius: var(--radius);
+/* ---------- Set Done Phase ---------- */
+#set-done-phase {
+  padding: 12px 0;
   text-align: center;
 }
+#set-entry-phase.hidden { display: none; }
 
 @keyframes slideUp {
   from { transform: translateY(100%); }
@@ -1444,7 +1407,6 @@ h3 { font-size: 1.125rem; font-weight: 600; margin: 20px 0 10px; }
 @supports (padding-top: env(safe-area-inset-top)) {
   #progress-bar { padding-top: env(safe-area-inset-top); }
   #rest-timer { padding-bottom: env(safe-area-inset-bottom); }
-  #backdate-prompt { padding-bottom: env(safe-area-inset-bottom); }
   body { padding-bottom: env(safe-area-inset-bottom); }
 }
 

--- a/index.html
+++ b/index.html
@@ -234,32 +234,41 @@
             <span id="current-set-label"></span>
             <span id="target-rir-label" class="pill pill-sm"></span>
           </div>
-          <div class="form-row">
-            <div class="form-group flex-1">
-              <label for="set-weight">Weight</label>
-              <input type="number" id="set-weight" class="input-lg" inputmode="decimal" min="0" step="2.5" placeholder="0" onfocus="this.select()">
+
+          <!-- Phase 1: Set Done button (starts rest timer) -->
+          <div id="set-done-phase">
+            <button class="btn btn-primary btn-xl" id="btn-set-done">Set Done</button>
+          </div>
+
+          <!-- Phase 2: Data entry (visible after Set Done) -->
+          <div id="set-entry-phase" class="hidden">
+            <div class="form-row">
+              <div class="form-group flex-1">
+                <label for="set-weight">Weight</label>
+                <input type="number" id="set-weight" class="input-lg" inputmode="decimal" min="0" step="2.5" placeholder="0" onfocus="this.select()">
+              </div>
+              <div class="form-group flex-1">
+                <label for="set-reps">Reps <span id="set-rep-range" class="pill pill-sm hidden"></span></label>
+                <input type="number" id="set-reps" class="input-lg" inputmode="numeric" min="0" max="100" placeholder="0" onfocus="this.select()">
+              </div>
             </div>
-            <div class="form-group flex-1">
-              <label for="set-reps">Reps <span id="set-rep-range" class="pill pill-sm hidden"></span></label>
-              <input type="number" id="set-reps" class="input-lg" inputmode="numeric" min="0" max="100" placeholder="0" onfocus="this.select()">
+            <p class="form-label">RIR</p>
+            <div class="chip-row" id="rir-chips">
+              <button class="chip" data-rir="0">0</button>
+              <button class="chip" data-rir="1">1</button>
+              <button class="chip" data-rir="2">2</button>
+              <button class="chip" data-rir="3">3+</button>
             </div>
+            <p class="form-label">Quick Notes</p>
+            <div class="chip-row" id="note-chips">
+              <button class="chip" data-note="Form">Form</button>
+              <button class="chip" data-note="Pain">Pain</button>
+              <button class="chip" data-note="Machine">Machine</button>
+              <button class="chip" data-note="Grip">Grip</button>
+            </div>
+            <input type="text" id="set-custom-note" class="input-sm" placeholder="Custom note...">
+            <button class="btn btn-primary btn-lg" id="btn-log-set">Save Set</button>
           </div>
-          <p class="form-label">RIR</p>
-          <div class="chip-row" id="rir-chips">
-            <button class="chip" data-rir="0">0</button>
-            <button class="chip" data-rir="1">1</button>
-            <button class="chip" data-rir="2">2</button>
-            <button class="chip" data-rir="3">3+</button>
-          </div>
-          <p class="form-label">Quick Notes</p>
-          <div class="chip-row" id="note-chips">
-            <button class="chip" data-note="Form">Form</button>
-            <button class="chip" data-note="Pain">Pain</button>
-            <button class="chip" data-note="Machine">Machine</button>
-            <button class="chip" data-note="Grip">Grip</button>
-          </div>
-          <input type="text" id="set-custom-note" class="input-sm" placeholder="Custom note...">
-          <button class="btn btn-primary btn-lg" id="btn-log-set">Log Set</button>
         </div>
 
         <!-- Log Bike Session (shown for conditioning machines) -->
@@ -278,6 +287,7 @@
           </div>
           <input type="text" id="next-time-custom" class="input-sm" placeholder="Custom note...">
           <button class="btn btn-primary" id="btn-save-next-time">Save & Continue</button>
+          <button class="btn btn-ghost btn-lg" id="btn-another-set" style="margin-top:8px;">Log Another Set</button>
         </div>
       </div>
     </section>
@@ -366,14 +376,6 @@
         <button class="chip" id="rest-mode-toggle"></button>
       </div>
       <button class="btn btn-sm btn-ghost" id="btn-dismiss-rest">Ready →</button>
-    </div>
-  </div>
-
-  <!-- Backdate Overlay (bottom sheet, stays until tapped) -->
-  <div id="backdate-overlay" class="hidden">
-    <div id="backdate-sheet">
-      <p id="backdate-title">When did you finish?</p>
-      <div id="backdate-chips"></div>
     </div>
   </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -12,7 +12,7 @@ import { hideRestTimer, toggleRestMode } from './timer.js';
 import {
   enterWorkout, renderWorkout, renderMachineView,
   clearBikeForm, saveBikeLog,
-  logSet, saveNextTimeNote,
+  setDone, logSet, saveNextTimeNote, logAnotherSet,
   setupWorkoutGlobals,
 } from './workout.js';
 import {
@@ -106,7 +106,6 @@ function setupEventListeners() {
   // Machine view
   $('btn-back-machine').onclick = () => {
     hideRestTimer();
-    $('backdate-overlay').classList.add('hidden');
     renderWorkout();
     showView('workout');
   };
@@ -155,7 +154,9 @@ function setupEventListeners() {
     };
   });
 
-  // Log set
+  // Set Done → starts rest timer, then data entry
+  $('btn-set-done').onclick = setDone;
+  // Save Set → logs the set data
   $('btn-log-set').onclick = logSet;
 
   // Next time chips
@@ -170,6 +171,7 @@ function setupEventListeners() {
     };
   });
   $('btn-save-next-time').onclick = saveNextTimeNote;
+  $('btn-another-set').onclick = logAnotherSet;
 
   // Rest timer
   $('rest-mode-toggle').onclick = toggleRestMode;

--- a/js/config.js
+++ b/js/config.js
@@ -6,7 +6,7 @@ export const STORAGE_KEY = 'gymApp_v1_data';
 export const SESSION_KEY = 'gymApp_v1_activeSession';
 // Version: date-based (YYYY.MM.DD + build letter). Update on every code change.
 // Same day: increment letter (a→b→c). New day: reset to 'a'.
-export const APP_VERSION = 'v2026.03.14a';
+export const APP_VERSION = 'v2026.03.14b';
 
 export const REST_TARGETS = {
   compound:  { normal: 90, hurry: 60 }, // seconds

--- a/js/session.js
+++ b/js/session.js
@@ -120,7 +120,6 @@ function endSession() {
   stopProgressTracking();
   hideRestTimer();
   clearActiveSession();
-  $('backdate-overlay').classList.add('hidden');
 
   // Show summary
   renderSessionSummary(sessionToSave);
@@ -132,7 +131,6 @@ function discardSession() {
   hideRestTimer();
   clearActiveSession();
   App.session = null;
-  $('backdate-overlay').classList.add('hidden');
   showView('home');
   renderHome();
 }

--- a/js/state.js
+++ b/js/state.js
@@ -15,7 +15,7 @@ export const App = {
   restMachineType: null,
   progressInterval: null,
   sessionStartTime: null,
-  backdateTimeout: null,
+  setDoneAt: null,       // timestamp when "Set Done" was tapped
   currentMachineId: null,
   currentBlockId: null,
   bikeReturnView: null,  // where to go back after bike log

--- a/js/workout.js
+++ b/js/workout.js
@@ -762,10 +762,10 @@ function renderSetLogger(machineId) {
     ? rirPattern[setNum - 1]
     : rirPattern[rirPattern.length - 1];
 
-  // Check if we've done all typical working sets (3)
+  // Check if we've done all typical working sets
   const typicalSets = rirPattern.length;
   if (setNum > typicalSets) {
-    // Show next-time suggestion
+    // Show next-time suggestion + option for more sets
     showNextTimeSuggestion(machineId);
     $('set-logger').classList.add('hidden');
     return;
@@ -797,6 +797,10 @@ function renderSetLogger(machineId) {
     $('set-weight').value = prevWeight || '';
     $('set-reps').value = '';
   }
+
+  // Reset to "Set Done" phase
+  $('set-done-phase').classList.remove('hidden');
+  $('set-entry-phase').classList.add('hidden');
 
   // Reset RIR chips
   $$('#rir-chips .chip').forEach(c => c.classList.remove('chip-active'));
@@ -855,7 +859,75 @@ function checkWeightUpCondition(machine, sets) {
 }
 
 // ============================================================
-// SET LOGGING
+// LOG ANOTHER SET (beyond RIR pattern)
+// ============================================================
+export function logAnotherSet() {
+  const machineId = App.currentMachineId;
+  if (!machineId) return;
+
+  const machine = App.data.machines[machineId];
+  if (!machine) return;
+
+  const sets = getMachineSets(machineId);
+  const setNum = sets.length + 1;
+  const rirPattern = machine.rirPattern || [2, 1, 1];
+  const targetRir = rirPattern[rirPattern.length - 1]; // use last RIR target
+
+  $('set-logger').classList.remove('hidden');
+  $('next-time-suggestion').classList.add('hidden');
+
+  $('current-set-label').textContent = `Set ${setNum}`;
+  $('target-rir-label').textContent = `Target: RIR ${targetRir}`;
+
+  // Show rep range
+  const repRangePill = $('set-rep-range');
+  if (machine.repRange && machine.repRange.max > 0) {
+    repRangePill.textContent = `${machine.repRange.min}–${machine.repRange.max}`;
+    repRangePill.classList.remove('hidden');
+  } else {
+    repRangePill.classList.add('hidden');
+  }
+
+  // Pre-fill weight from last set
+  const lastSet = sets.length > 0 ? sets[sets.length - 1] : null;
+  $('set-weight').value = lastSet ? lastSet.weight : '';
+  $('set-reps').value = '';
+
+  // Reset to Set Done phase
+  $('set-done-phase').classList.remove('hidden');
+  $('set-entry-phase').classList.add('hidden');
+
+  // Reset chips
+  $$('#rir-chips .chip').forEach(c => c.classList.remove('chip-active'));
+  $$('#note-chips .chip').forEach(c => c.classList.remove('chip-active'));
+  $('set-custom-note').value = '';
+}
+
+// ============================================================
+// SET DONE — Phase 1: start rest timer, switch to data entry
+// ============================================================
+const AUTO_OFFSET_SEC = 4; // approximate delay picking up phone after set
+
+export function setDone() {
+  const machineId = App.currentMachineId;
+  if (!machineId || !App.session) return;
+
+  // Record when the set was actually finished (with auto-offset)
+  App.setDoneAt = isoNow();
+
+  // Start rest timer immediately with auto-offset
+  const machine = App.data.machines[machineId];
+  if (machine && machine.type !== 'conditioning') {
+    startRestTimer(machine.type, AUTO_OFFSET_SEC);
+  }
+
+  // Switch to data entry phase
+  $('set-done-phase').classList.add('hidden');
+  $('set-entry-phase').classList.remove('hidden');
+}
+
+// ============================================================
+// SET LOGGING — Phase 2: save set data
 // ============================================================
 export function logSet() {
   const machineId = App.currentMachineId;
@@ -892,9 +964,8 @@ export function logSet() {
     weight,
     reps,
     rir,
-    finishedOffsetSec: 0,
     notes,
-    loggedAt: isoNow(),
+    loggedAt: App.setDoneAt || isoNow(),
   };
 
   App.session.sets.push(setData);
@@ -905,13 +976,16 @@ export function logSet() {
   saveData();
   saveActiveSession();
 
+  // Clear setDoneAt
+  App.setDoneAt = null;
+
   // Re-render
   renderLoggedSets(machineId);
   renderSetLogger(machineId);
   updatePillRow();
   updateSegmentBar();
 
-  // Undo callback — passed to backdate, toast fires only after offset selection (issue #6)
+  // Undo callback
   const undoFn = () => {
     const idx = App.session.sets.indexOf(setData);
     if (idx > -1) {
@@ -925,43 +999,7 @@ export function logSet() {
     }
   };
 
-  // Show backdate prompt — toast fires after user picks offset
-  showBackdatePrompt(setData, setNumber, undoFn);
-}
-
-// ============================================================
-// BACKDATE PROMPT
-// ============================================================
-function showBackdatePrompt(setData, setNumber, undoFn) {
-  const overlay = $('backdate-overlay');
-  const chipsContainer = $('backdate-chips');
-  const offsets = App.data.profile.preferences.finishedSetOffsetOptionsSec || [0, 5, 10, 20, 30, 60];
-
-  chipsContainer.innerHTML = '';
-
-  offsets.forEach((offset, i) => {
-    const chip = document.createElement('button');
-    chip.className = `chip ${i === 0 ? 'chip-active' : ''}`;
-    chip.textContent = offset === 0 ? 'Now' : `-${offset}s`;
-    chip.onclick = () => {
-      setData.finishedOffsetSec = offset;
-      saveActiveSession();
-      overlay.classList.add('hidden');
-
-      // Start rest timer with offset
-      const machine = App.data.machines[setData.machineId];
-      if (machine && machine.type !== 'conditioning') {
-        startRestTimer(machine.type, offset);
-      }
-
-      // Toast fires here — after user picks offset (issue #6)
-      showToast(`Set ${setNumber} saved`, undoFn);
-    };
-    chipsContainer.appendChild(chip);
-  });
-
-  overlay.classList.remove('hidden');
-  // No auto-dismiss — stays until user taps a chip (issue #5)
+  showToast(`Set ${setNumber} saved`, undoFn);
 }
 
 // ============================================================


### PR DESCRIPTION
- New two-phase set logging: tap "Set Done" to start rest timer (with auto 4s offset), then enter weight/reps/RIR and tap "Save Set"
- Remove backdate overlay entirely — no extra tap per set
- Allow logging additional sets beyond the RIR pattern length via "Log Another Set" button shown alongside next-time suggestions
- Rest timer now runs during data entry, matching real-world workflow

https://claude.ai/code/session_01DwrUerkFWTALGUmEt5gvQX