### PR TITLE
Regroup compound suggestions with OR logic (issue #36)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -259,6 +259,13 @@ function init() {
     }
   });
 
+  // Always refresh built-in templates from defaults — templates aren't user-editable,
+  // so this lets users pick up structural changes (e.g. issue #36 compound regroup).
+  Object.entries(DEFAULT_DATA.templates).forEach(([id, def]) => {
+    App.data.templates[id] = deepClone(def);
+  });
+  saveData();
+
   // Setup event listeners
   setupEventListeners();
   setupSettingsListeners();

--- a/js/config.js
+++ b/js/config.js
@@ -6,7 +6,7 @@ export const STORAGE_KEY = 'gymApp_v1_data';
 export const SESSION_KEY = 'gymApp_v1_activeSession';
 // Version: date-based (YYYY.MM.DD + build letter). Update on every code change.
 // Same day: increment letter (a→b→c). New day: reset to 'a'.
-export const APP_VERSION = 'v2026.03.15a';
+export const APP_VERSION = 'v2026.04.08a';
 
 export const REST_TARGETS = {
   compound:  { normal: 90, hurry: 60 }, // seconds

--- a/js/data-defaults.js
+++ b/js/data-defaults.js
@@ -895,14 +895,15 @@ export const DEFAULT_DATA = {
           "id": "primary",
           "name": "Primary Compound",
           "suggestions": [
-            "chest_press"
+            "incline_press"
           ]
         },
         {
           "id": "secondary",
-          "name": "Secondary",
+          "name": "Secondary Compound",
+          "completion": "any",
           "suggestions": [
-            "incline_press",
+            "chest_press",
             "shoulder_press"
           ]
         },
@@ -941,6 +942,7 @@ export const DEFAULT_DATA = {
         {
           "id": "primary",
           "name": "Primary Compound",
+          "completion": "any",
           "suggestions": [
             "lat_pulldown",
             "assisted_chin"
@@ -948,7 +950,7 @@ export const DEFAULT_DATA = {
         },
         {
           "id": "secondary",
-          "name": "Secondary",
+          "name": "Secondary Compound",
           "suggestions": [
             "seated_row"
           ]

--- a/js/workout.js
+++ b/js/workout.js
@@ -514,7 +514,13 @@ function isBlockComplete(block) {
     const allMachines = [...(block.suggestions || []), ...(App.session._ui.otherMachines || [])];
     return allMachines.some(mid => getMachineSets(mid).length > 0);
   }
-  // A block is "complete" if every machine has at least one set
+  // Choice-based blocks (e.g. compound primary/secondary with multiple options):
+  // complete if ANY listed machine has at least one set. Reflects that compound
+  // movements are interchangeable and fatigue/order shouldn't force redundant work.
+  if (block.completion === 'any') {
+    return block.suggestions.some(mid => getMachineSets(mid).length > 0);
+  }
+  // Default: a block is "complete" only if every machine has at least one set
   return block.suggestions.every(mid => getMachineSets(mid).length > 0);
 }
 


### PR DESCRIPTION
Push: primary=Incline Press; secondary=Chest Press OR Shoulder Press.
Pull: primary=Lat Pulldown OR Assisted Chin; secondary=Seated Row.

Blocks with `completion: "any"` are marked done as soon as any one of
their listed machines has at least one logged set, so fatigue/order
doesn't force redundant compound work or false "incomplete" states.

Built-in templates are now refreshed from defaults on init so existing
users pick up the new structure without resetting their data.