### PR TITLE
Add MTS Row as a pull-day alternative to Seated Row

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -252,9 +252,14 @@ function init() {
     if (!m._setup) m._setup = {};
   });
 
-  // Always refresh machine tips from defaults (tips are static content, not user data)
+  // Seed any machines missing from user data (new machines added to DEFAULT_DATA
+  // in a later app version), then refresh tips from defaults since tips are static
+  // content, not user data.
   Object.entries(DEFAULT_DATA.machines).forEach(([id, def]) => {
-    if (App.data.machines[id]) {
+    if (!App.data.machines[id]) {
+      App.data.machines[id] = deepClone(def);
+      App.data.machines[id]._setup = {};
+    } else {
       App.data.machines[id].tips = def.tips;
     }
   });

--- a/js/config.js
+++ b/js/config.js
@@ -6,7 +6,7 @@ export const STORAGE_KEY = 'gymApp_v1_data';
 export const SESSION_KEY = 'gymApp_v1_activeSession';
 // Version: date-based (YYYY.MM.DD + build letter). Update on every code change.
 // Same day: increment letter (a→b→c). New day: reset to 'a'.
-export const APP_VERSION = 'v2026.04.09a';
+export const APP_VERSION = 'v2026.04.09b';
 
 export const REST_TARGETS = {
   compound:  { normal: 90, hurry: 60 }, // seconds
@@ -35,6 +35,7 @@ export const SEED_WEIGHTS = {
   triceps_extension_machine: 40,   // 2/14: 40 ×3×13
   lat_pulldown:              70,   // last logged 75 but note says drop to 70 for form
   seated_row:                75,   // 2/17: 75 ×3×10
+  mts_row:                   30,   // per-side starting weight (plate loaded)
   biceps_curl_machine:       25,   // 2/17: 25 ×3×12
   assisted_chin:             70,   // 2/17: 70 lb assist ×3×12 (higher = more assistance = easier)
   seated_leg_press:         180,   // 2/19: 180 ×3×13

--- a/js/config.js
+++ b/js/config.js
@@ -6,7 +6,7 @@ export const STORAGE_KEY = 'gymApp_v1_data';
 export const SESSION_KEY = 'gymApp_v1_activeSession';
 // Version: date-based (YYYY.MM.DD + build letter). Update on every code change.
 // Same day: increment letter (a→b→c). New day: reset to 'a'.
-export const APP_VERSION = 'v2026.04.08a';
+export const APP_VERSION = 'v2026.04.09a';
 
 export const REST_TARGETS = {
   compound:  { normal: 90, hurry: 60 }, // seconds

--- a/js/data-defaults.js
+++ b/js/data-defaults.js
@@ -460,6 +460,11 @@ export const DEFAULT_DATA = {
           "type": "number"
         },
         {
+          "key": "grip",
+          "label": "Grip (neutral / over / under)",
+          "type": "text"
+        },
+        {
           "key": "notes",
           "label": "Setup Notes",
           "type": "text"
@@ -1084,7 +1089,7 @@ export const DEFAULT_DATA = {
             "seated_leg_press",
             "chest_press",
             "lat_pulldown",
-            "seated_row"
+            "mts_row"
           ]
         },
         {

--- a/js/data-defaults.js
+++ b/js/data-defaults.js
@@ -433,6 +433,51 @@ export const DEFAULT_DATA = {
       "familiarity": "learning",
       "lastUsedAt": null
     },
+    "mts_row": {
+      "id": "mts_row",
+      "name": "MTS Row",
+      "category": "pull",
+      "type": "compound",
+      "variants": [],
+      "repRange": {
+        "min": 8,
+        "max": 12
+      },
+      "rirPattern": [
+        3,
+        2,
+        1
+      ],
+      "setupFields": [
+        {
+          "key": "seat",
+          "label": "Seat",
+          "type": "number"
+        },
+        {
+          "key": "start",
+          "label": "Start/Range",
+          "type": "number"
+        },
+        {
+          "key": "notes",
+          "label": "Setup Notes",
+          "type": "text"
+        }
+      ],
+      "tips": {
+        "setup": "**Setup**\n\u2022 🪑 Seat so handles line up with your lower chest / upper abs at the finish.\n\u2022 🧱 Chest pad firm against your sternum \u2014 ribs quiet, shoulders relaxed.\n\u2022 🏗️ Load plates evenly on both sides; start light to dial in the groove.\n\u2022 ✋ Pick a grip: neutral = balanced lats, overhand = more upper back, underhand = more lats/biceps.",
+        "form": "**Execution**\n\u2022 🎯 Drive elbows back and down \u2014 think \u201celbow into back pocket.\u201d\n\u2022 🧱 Keep chest planted on the pad; don\u2019t push yourself off with the pull.\n\u2022 🤏 Pause briefly at peak contraction, squeeze mid-back.\n\u2022 🐢 Control the eccentric \u2014 let the arm stretch fully without dumping the weight.\n\n**Iso-lateral advantage**\n\u2022 ⚖️ Arms move independently \u2014 match reps to your weaker side.\n\u2022 Try alternating arms if you want a bigger anti-rotation / core demand.\n\n**Fix common issues**\n\u2022 Biceps dominating \u2192 thumbless grip; lead with the elbow, not the hand.\n\u2022 Shrugging at top \u2192 depress shoulder blades before you pull.\n\u2022 Chest lifting off pad \u2192 lighten load; stop pulling past end range.\n\n**Tempo**\n\u2022 \u23f1\ufe0f 1\u20132 sec pull, 1 sec squeeze, 2\u20133 sec return",
+        "mantra": [
+          "🧱 chest glued to pad",
+          "↩️ elbows to pockets",
+          "🤏 squeeze & stretch"
+        ],
+        "phasedCues": {}
+      },
+      "familiarity": "learning",
+      "lastUsedAt": null
+    },
     "biceps_curl_machine": {
       "id": "biceps_curl_machine",
       "name": "Biceps Curl (Machine)",
@@ -951,8 +996,10 @@ export const DEFAULT_DATA = {
         {
           "id": "secondary",
           "name": "Secondary Compound",
+          "completion": "any",
           "suggestions": [
-            "seated_row"
+            "seated_row",
+            "mts_row"
           ]
         },
         {


### PR DESCRIPTION
Introduces a new mts_row machine (Hammer Strength Iso-Lateral) with setup
and form tips, and adds it alongside seated_row in the pull_default
Secondary Compound block with completion:"any" so either counts. Also
seeds missing machines from DEFAULT_DATA on init so returning users pick
up newly added machines.